### PR TITLE
Register custom dataparser to avoid failure with ns-train

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,7 @@ include = ["splatfactow*", "splatfactow_light*"]
 [project.entry-points.'nerfstudio.method_configs']
 splatfactow = 'splatfactow.splatfactow_config:splatfactow_config'
 splatfactow_light = 'splatfactow.splatfactow_config:splatfactow_light_config'
+
+# register the dataparser config
+[project.entry-points.'nerfstudio.dataparser_configs']
+splatfactow_dataparser = 'splatfactow.nerfw_dataparser:splatfactow_dataparser'

--- a/splatfactow/nerfw_dataparser.py
+++ b/splatfactow/nerfw_dataparser.py
@@ -32,6 +32,7 @@ from nerfstudio.data.dataparsers.base_dataparser import (
 )
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.data.utils import colmap_parsing_utils as colmap_utils
+from nerfstudio.plugins.registry_dataparser import DataParserSpecification
 
 # TODO(1480) use pycolmap instead of colmap_parsing_utils
 # import pycolmap
@@ -342,3 +343,6 @@ class NerfW(DataParser):
 
     def find_eval_idx(self, idx):
         return self.i_eval[idx]
+
+
+splatfactow_dataparser=DataParserSpecification(config=NerfWDataParserConfig())


### PR DESCRIPTION
Relates to https://github.com/KevinXu02/splatfacto-w/issues/18

When I tried to run `ns-train splatfacto-w-light`, I got a long error like:

```
AssertionError: pipeline.datamanager.dataparser was provided a default value of type <class 'splatfactow.nerfw_dataparser.NerfWDataParserConfig'> but no matching subcommand was found. A type may be missing in the Union type declaration for pipeline.datamanager.dataparser, which currently expects [typing.Annotated[nerfstudio.data.dataparsers.nerfstudio_dataparser.NerfstudioDataParserConfig, _SubcommandConfiguration(name='nerfstudio-data', default=NerfstudioDataParserConfig(_target=<class 'nerfstudio.data.dataparsers.nerfstudio_dataparser.Nerfstudio'>, data=PosixPath('.'), scale_factor=1.0, downscale_factor=None, scene_scale=1.0, orientation_method='up', center_method='poses', auto_scale_poses=True, eval_mode='fraction', 
```

After looking into it, I realized that this package was missing the [registration of the custom data parser](https://docs.nerf.studio/developer_guides/new_methods.html#registering-custom-dataparser-with-nerfstudio).  So I did it.  Tested locally and now ns-train works!